### PR TITLE
fixed exception with RadialController on Windows 10 Mobile devices

### DIFF
--- a/src/AllJoynSampleApp/DeviceViews/LightClientView.xaml.cs
+++ b/src/AllJoynSampleApp/DeviceViews/LightClientView.xaml.cs
@@ -58,7 +58,10 @@ namespace AllJoynSampleApp.DeviceViews
         {
             if (!ApiInformation.IsTypePresent(typeof(RadialController).FullName))
                 return;
-            myController = RadialController.CreateForCurrentView();
+
+            if (RadialController.IsSupported())
+                myController = RadialController.CreateForCurrentView();
+
             if (myController == null)
                 return;
 


### PR DESCRIPTION
RadialController.IsSupported() check was added 